### PR TITLE
Add strings

### DIFF
--- a/spago.dhall
+++ b/spago.dhall
@@ -34,6 +34,7 @@ You can edit this file as you like.
   , "random"
   , "refs"
   , "sized-vectors"
+  , "strings"
   , "tuples"
   , "typelevel"
   , "wags"


### PR DESCRIPTION
I found that `strings` package is needed.

Without it, `WAGSI.Cookbook.IowaPiano` does not compile.